### PR TITLE
Add support for UART_D and UART_E devices

### DIFF
--- a/src/logger.rs
+++ b/src/logger.rs
@@ -7,6 +7,8 @@ pub enum Type {
     A,
     B,
     C,
+    D,
+    E,
 }
 
 struct UARTLogger {
@@ -20,6 +22,8 @@ impl UARTLogger {
             Type::A => UART::A,
             Type::B => UART::B,
             Type::C => UART::C,
+            Type::D => UART::D,
+            Type::E => UART::E,
         }
     }
 

--- a/src/tegra210/clock/mod.rs
+++ b/src/tegra210/clock/mod.rs
@@ -31,6 +31,7 @@ const CLK_RST_CONTROLLER_CLK_SOURCE_UARTB: u32 = 0x17C;
 const CLK_RST_CONTROLLER_CLK_SOURCE_HOST1X: u32 = 0x180;
 const CLK_RST_CONTROLLER_CLK_SOURCE_UARTC: u32 = 0x1A0;
 const CLK_RST_CONTROLLER_CLK_SOURCE_UARTD: u32 = 0x1C0;
+const CLK_RST_CONTROLLER_CLK_SOURCE_UARTE: u32 = 0x710;
 const CLK_RST_CONTROLLER_CLK_SOURCE_TSEC: u32 = 0x1F4;
 const CLK_RST_CONTROLLER_CLK_SOURCE_SOR1: u32 = 0x410;
 
@@ -59,6 +60,22 @@ impl Clock {
         enable: CLK_RST_CONTROLLER_CLK_OUT_ENB_H,
         source: CLK_RST_CONTROLLER_CLK_SOURCE_UARTC,
         index: 0x17,
+        clock_source: 0,
+        clock_divisor: 0,
+    };
+    pub const UART_D: Clock = Clock {
+        reset: CLK_RST_CONTROLLER_RST_DEVICES_U,
+        enable: CLK_RST_CONTROLLER_CLK_OUT_ENB_U,
+        source: CLK_RST_CONTROLLER_CLK_SOURCE_UARTD,
+        index: 0x1,
+        clock_source: 0,
+        clock_divisor: 0,
+    };
+    pub const UART_E: Clock = Clock {
+        reset: CLK_RST_CONTROLLER_RST_DEVICES_Y,
+        enable: CLK_RST_CONTROLLER_CLK_OUT_ENB_Y,
+        source: CLK_RST_CONTROLLER_CLK_SOURCE_UARTE,
+        index: 0x14,
         clock_source: 0,
         clock_divisor: 0,
     };

--- a/src/tegra210/uart/mod.rs
+++ b/src/tegra210/uart/mod.rs
@@ -45,10 +45,14 @@ impl UART {
         register_base: 0x7000_6200 as *const UARTRegister,
         clock: &Clock::UART_C,
     };
-
-    // TODO: setup clocks for them
-    //pub const D: Self = UART { register_base: 0x70006300, clock: Clock::UART_D };
-    //pub const E: Self = UART { register_base: 0x70006400, clock: Clock::UART_E };
+    pub const D: Self = UART {
+        register_base: 0x7000_6300 as *const UARTRegister,
+        clock: &Clock::UART_D,
+    };
+    pub const E: Self = UART {
+        register_base: 0x7000_6400 as *const UARTRegister,
+        clock: &Clock::UART_E
+    };
 
     pub fn init(&self, baud: u32) {
         self.clock.enable();


### PR DESCRIPTION
This Pull Request adds support for `UART_D` and `UART_E` devices by configuring the corresponding clocks and adding constants for them in the `UART` impl.

I also populated the `Type` enum so the logger can make use of these devices as well.